### PR TITLE
 Add devices=all permission

### DIFF
--- a/me.proton.Mail.yml
+++ b/me.proton.Mail.yml
@@ -6,6 +6,7 @@ base: org.electronjs.Electron2.BaseApp
 base-version: *runtime-version
 command: start-proton-mail
 finish-args:
+  - --device=all
   - --share=ipc
   - --share=network
   - --socket=wayland


### PR DESCRIPTION
`all` is needed for authentication with hardware keys (e.g. YubiKey) to work.

See https://github.com/flathub/me.proton.Pass/pull/14