### PR TITLE
Revert "proton-mail: Update ProtonMail.deb to 1.1.2"

### DIFF
--- a/me.proton.Mail.metainfo.xml
+++ b/me.proton.Mail.metainfo.xml
@@ -122,11 +122,8 @@
     <content_rating type="oars-1.1"/>
 
     <releases>
-        <release version="1.1.2" date="2024-09-23">
-            <description></description>
-        </release>
         <release version="1.0.6" date="2024-08-22">
-            <description/>
+            <description></description>
         </release>
         <release version="1.0.6" date="2024-08-20">
             <description/>

--- a/me.proton.Mail.yml
+++ b/me.proton.Mail.yml
@@ -45,8 +45,8 @@ modules:
       - type: file
         dest-filename: ProtonMail.deb
         only-arches: [x86_64]
-        url: https://proton.me/download/mail/linux/1.1.2/ProtonMail-desktop-beta.deb
-        sha512: ce5568970c64da64a4bfe8cd88c2c42dc2edf7d1d502e0c0150eb9cd64ebad6faf3b5269ed942a7a64c398006fda738b55656e9a69aa7a6b15233d9b497a11d2
+        url: https://proton.me/download/mail/linux/ProtonMail-desktop-beta.deb
+        sha512: fb51c0cd2124188ec40ba38c863933905a26a7457e8738048865ed4a43feb6afb30df8f20924eccfaca9e69e17f0b63960fc2e986edaaf714906d56534b8b462
         x-checker-data:
           type: json
           url: https://proton.me/download/mail/linux/version.json


### PR DESCRIPTION
Reverts flathub/me.proton.Mail#16

Report in https://github.com/flathub/me.proton.Mail/issues/17#issuecomment-2392460015 shows that 1.1.2 can not open.