### PR TITLE
workaround unable to open

### DIFF
--- a/me.proton.Mail.yml
+++ b/me.proton.Mail.yml
@@ -9,11 +9,10 @@ finish-args:
   - --device=all
   - --share=ipc
   - --share=network
-  - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   - --talk-name=org.freedesktop.secrets
   - --env=XCURSOR_PATH=~/.icons:/app/share/icons:/icons:/run/host/user-share/icons:/run/host/share/icons
-  - --env=ELECTRON_OZONE_PLATFORM_HINT=auto
+  - --env=ELECTRON_OZONE_PLATFORM_HINT=x11
 modules:
   - shared-modules/libsecret/libsecret.json
   - name: proton-mail

--- a/me.proton.Mail.yml
+++ b/me.proton.Mail.yml
@@ -12,6 +12,7 @@ finish-args:
   - --socket=x11
   - --talk-name=org.freedesktop.secrets
   - --env=XCURSOR_PATH=~/.icons:/app/share/icons:/icons:/run/host/user-share/icons:/run/host/share/icons
+  # Workaround https://github.com/flathub/me.proton.Mail/issues/17
   - --env=ELECTRON_OZONE_PLATFORM_HINT=x11
 modules:
   - shared-modules/libsecret/libsecret.json


### PR DESCRIPTION
For some reason, it needs to start with X11 when it first starts. Workaround https://github.com/flathub/me.proton.Mail/issues/17