### PR TITLE
Update runtime to 25.08

### DIFF
--- a/me.proton.Mail.yml
+++ b/me.proton.Mail.yml
@@ -1,6 +1,6 @@
 app-id: me.proton.Mail
 runtime: org.freedesktop.Platform
-runtime-version: &runtime-version '24.08'
+runtime-version: &runtime-version '25.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
 base-version: *runtime-version
@@ -27,30 +27,7 @@ modules:
           type: anitya
           project-id: 5356
           url-template: https://gitlab.freedesktop.org/dbus/dbus/-/archive/dbus-$version/dbus-dbus-$version.tar.gz
-  # fix auto logout
-  # https://github.com/flathub/org.signal.Signal/pull/756/commits/2caf105b18f906e7707f67b3cf7384a21f461564
-  - name: libsecret
-    buildsystem: meson
-    config-opts:
-      - -Dmanpage=false
-      - -Dcrypto=disabled
-      - -Dvapi=false
-      - -Dgtk_doc=false
-      - -Dintrospection=false
-      - -Dbash_completion=disabled
-    cleanup:
-      - /bin
-      - /include
-      - /lib/pkgconfig
-      - /share/man
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libsecret/0.21/libsecret-0.21.7.tar.xz
-        sha256: 6b452e4750590a2b5617adc40026f28d2f4903de15f1250e1d1c40bfd68ed55e
-        x-checker-data:
-          type: gnome
-          name: libsecret
-          stable-only: true
+
   - name: proton-mail
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
Also drop libsecret module that org.electronjs.Electron2.BaseApp version 25.08 provides it with the following [config-opts](https://github.com/flathub/org.electronjs.Electron2.BaseApp/blob/branch/25.08/org.electronjs.Electron2.BaseApp.yml#L29-L35); therefore, it no longer needs to be compiled (unless the project requires a specific version of this dependency).

Fixes https://github.com/flathub/me.proton.Mail/issues/53