### PR TITLE
Replace `patch-desktop-filename` with `patch-electron-desktop-filename`

### DIFF
--- a/me.proton.Mail.yml
+++ b/me.proton.Mail.yml
@@ -48,7 +48,7 @@ modules:
       - install -Dm644 usr/share/applications/proton-mail.desktop "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
       - desktop-file-edit --set-key=Exec --set-value='start-proton-mail %U' --set-icon=${FLATPAK_ID}
         "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"
-      - patch-desktop-filename "${FLATPAK_DEST}/proton-mail/resources/app.asar"
+      - patch-electron-desktop-filename "${FLATPAK_DEST}/proton-mail/resources/app.asar"
 
       # Install the wrapper script to start it.
       - install -Dm 755 start-proton-mail.sh /app/bin/start-proton-mail


### PR DESCRIPTION
`patch-desktop-filename` is deprecated and will be removed in 26.08. It's replaced by `patch-electron-desktop-filename`. See flathub/org.electronjs.Electron2.BaseApp#65 for details.